### PR TITLE
Review articles and source for additional methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ List of software packages (and the people developing these methods) for single-c
 
 - [CrazyHotTommy's RNA-seq analysis list](https://github.com/crazyhottommy/RNA-seq-analysis#single-cell-rna-seq) - Very broad list that includes some single cell RNA-seq packages and papers.
 - [lazappi's Single-cell Software table](https://github.com/lazappi/awesome-single-cell) - Table of single cell software and it's functions. Live version [here](https://goo.gl/4wcVwn).
+- [agitter's Pseudotime estimation list](https://github.com/agitter/single-cell-pseudotime) - An overview of algorithms for estimating pseudotime in single-cell RNA-seq data.
 
 ## People
 

--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,8 @@ SCOUP: https://github.com/hmatsu1226/SCOUP
 
 Ouija: https://github.com/kieranrcampbell/ouija
 
+Others listed at https://github.com/agitter/single-cell-pseudotime
+
 # Pipelines
 
 Seurat http://www.satijalab.org/seurat.html

--- a/TODO.md
+++ b/TODO.md
@@ -103,3 +103,11 @@ DNA SNV calling: https://bitbucket.org/hamimzafar/monovar
 # Methylation
 
 Prediction of missing information: https://github.com/cangermueller/deepcpg
+
+# Reviews
+
+Design and computational analysis of single-cell RNA-sequencing experiments: https://doi.org/10.1186/s13059-016-0927-y
+
+Defining cell types and states with single-cell genomics: https://doi.org/10.1101/gr.190595.115
+
+Scaling single-cell genomics from phenomenology to mechanism: https://doi.org/10.1038/nature21350

--- a/TODO.md
+++ b/TODO.md
@@ -69,8 +69,6 @@ SCOUP: https://github.com/hmatsu1226/SCOUP
 
 Ouija: https://github.com/kieranrcampbell/ouija
 
-Others listed at https://github.com/agitter/single-cell-pseudotime
-
 # Pipelines
 
 Seurat http://www.satijalab.org/seurat.html


### PR DESCRIPTION
I'm adding these to the TODO list instead of the main page because I'm unsure whether they are in scope:
- Three review articles
- A list I maintain that is specific to methods for pseudotime estimation and related problems, which could be scraped to populate the list here