### PR TITLE
Add DALI

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ List of software packages (and the people developing these methods) for single-c
 
 ### Immune receptor profiling
 
+- [DALI](https://github.com/vibscc/DALI) - [R] Diversity AnaLysis Interface (DALI) is a tool that enables TCR and BCR analysis in the Seurat ecosystem. The functionality of the tool is also exposed via an interactive Shiny application. 
 - [Scirpy](https://github.com/icbi-lab/scirpy) - [Python] - [A Scanpy extension for analyzing single-cell T-cell receptor (TCR) sequencing data](https://www.biorxiv.org/content/10.1101/2020.04.10.035865v1).
 - [TraCeR](http://github.com/teichlab/tracer) - [python] - Reconstruction of T-Cell receptor sequences from single-cell RNA-seq data.
 - [TRAPeS](https://github.com/yoseflab/trapes) - [python, C++] - TRAPeS (TCR Reconstruction Algorithm for Paired-End Single-cell), a software for reconstruction of T cell receptors (TCR) using short, paired-end single-cell RNA-sequencing.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ List of software packages (and the people developing these methods) for single-c
 - [SINCERITIES](https://github.com/CABSEL/SINCERITIES) - [R/Matlab] - [Inferring gene regulatory networks from time-stamped single cell transcriptional expression profiles](https://academic.oup.com/bioinformatics/article/34/2/258/4158033)
 
 
-### TCR analysis
+### Immune receptor profiling
 
 - [Scirpy](https://github.com/icbi-lab/scirpy) - [Python] - [A Scanpy extension for analyzing single-cell T-cell receptor (TCR) sequencing data](https://www.biorxiv.org/content/10.1101/2020.04.10.035865v1).
 - [TraCeR](http://github.com/teichlab/tracer) - [python] - Reconstruction of T-Cell receptor sequences from single-cell RNA-seq data.


### PR DESCRIPTION
This adds the DALI tool for the analysis of single cell TCR and BCR data.
Since there was no real category for this, the category 'TCR' has been renamed to a more general 'Immune receptor profiling'