### PR TITLE
update scRepertoire's links for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ List of software packages (and the people developing these methods) for single-c
 - [APackOfTheClones](https://github.com/Qile0317/APackOfTheClones) - [R] - [APackOfTheClones: Visualization of clonal expansion with circle packing](https://joss.theoj.org/papers/eb9d2b2fc3ffb1d440bd7120b66f1f71)
 - [DALI](https://github.com/vibscc/DALI) - [R] - Diversity Analysis Interface (DALI) is a tool that enables TCR and BCR analysis in the Seurat ecosystem. The functionality of the tool is also exposed via an interactive Shiny application.
 - [Scirpy](https://github.com/icbi-lab/scirpy) - [Python] - [A Scanpy extension for analyzing single-cell T-cell receptor (TCR) sequencing data](https://www.biorxiv.org/content/10.1101/2020.04.10.035865v1).
-- [scRepertoire](https://github.com/ncborcherding/scRepertoire) - [R] - [scRepertoire: An R-based toolkit for single-cell immune receptor analysis](https://doi.org/10.12688/f1000research.22139.2)
+- [scRepertoire](https://github.com/BorchLab/scRepertoire) - [R] - [scRepertoire 2: Enhanced and efficient toolkit for single-cell immune profiling](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1012760)
 - [TraCeR](http://github.com/teichlab/tracer) - [python] - Reconstruction of T-Cell receptor sequences from single-cell RNA-seq data.
 - [TRAPeS](https://github.com/yoseflab/trapes) - [python, C++] - TRAPeS (TCR Reconstruction Algorithm for Paired-End Single-cell), a software for reconstruction of T cell receptors (TCR) using short, paired-end single-cell RNA-sequencing.
 


### PR DESCRIPTION
We have recently published a paper for version 2 of scRepertoire, and this PR updates the citation link and paper title.