### PR TITLE
add trust4 to immune receptor profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ List of software packages (and the people developing these methods) for single-c
 - [scRepertoire](https://github.com/ncborcherding/scRepertoire) - [R] - [scRepertoire: An R-based toolkit for single-cell immune receptor analysis](https://doi.org/10.12688/f1000research.22139.2)
 - [TraCeR](http://github.com/teichlab/tracer) - [python] - Reconstruction of T-Cell receptor sequences from single-cell RNA-seq data.
 - [TRAPeS](https://github.com/yoseflab/trapes) - [python, C++] - TRAPeS (TCR Reconstruction Algorithm for Paired-End Single-cell), a software for reconstruction of T cell receptors (TCR) using short, paired-end single-cell RNA-sequencing.
+- [TRUST4](https://github.com/liulab-dfci/TRUST4) - [bash] - [TRUST4: immune repertoire reconstruction from bulk and single-cell RNA-seq data](https://www.nature.com/articles/s41592-021-01142-2)
 
 ### Marker and differential gene expression identification
 


### PR DESCRIPTION
This PR adds the command line tool TRUST4 to the immune receptor profiling section